### PR TITLE
商品一覧 表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new
@@ -19,6 +20,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :describe, :category_id, :condition_id, :postage_id, :prefecture_id, :delivery_day_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :describe, :category_id, :condition_id, :postage_id, :prefecture_id, :delivery_day_id, :price, :image).merge(ç current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :describe, :category_id, :condition_id, :postage_id, :prefecture_id, :delivery_day_id, :price, :image).merge(ç current_user.id)
+    params.require(:item).permit(:name, :describe, :category_id, :condition_id, :postage_id, :prefecture_id, :delivery_day_id, :price, :image).merge(user_id:current_user.id)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../price")

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,14 +123,16 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
       <li class='list'>
+      <% @items.each do |item| %>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached?%>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,16 +143,17 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% if @items %>
+      <% if @items != nil  %>
       <% @items.each do |item| %>
       <li class='list'>
       

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,6 +127,7 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if @items %>
       <% @items.each do |item| %>
       <li class='list'>
       
@@ -134,10 +135,12 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached?%>
 
+      
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+      
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
@@ -157,7 +160,7 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+      <% else %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -181,13 +184,14 @@
       <%# /商品がない場合のダミー %>
     </ul>
   </div>
+      <% end%>
   <%# /商品一覧 %>
 </div>
 
 <div class='purchase-btn'>
   <span><%= link_to '出品する', new_item_path, class:'purchase-btn-text'%></span>
     <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-
+      
 
 </div>
 <%= render "shared/footer" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,9 +127,9 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      
-      <li class='list'>
       <% @items.each do |item| %>
+      <li class='list'>
+      
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached?%>


### PR DESCRIPTION

#What
商品一覧 表示機能

#Why

見本furimaの一覧表示は横に並んでいるのに対して
私の一覧表示は縦に並んでしまっていますが、
実装条件には「上から、出品された日時が新しい順に表示されること」
とあるのでこれで良いのかとプルリクエストとさせていただきます。

新規投稿が丈夫にくる確認動画です。

https://gyazo.com/17ff845a17c679593ce9f7bdd6e9090b
https://gyazo.com/1ae2f0770b1c5f15a1239ebf5fd2cdb5

よろしくお願いします